### PR TITLE
[GUi] - fix center plugin display

### DIFF
--- a/gui/src/components/layout/PageTabsLayout.tsx
+++ b/gui/src/components/layout/PageTabsLayout.tsx
@@ -45,7 +45,7 @@ export const PageTabsLayout: React.FC<PageProps> = ({ title, children, navigatio
           </NavigationMenu>
         </div>
       )}
-      <main className="flex flex-col m-2 flex-1 overflow-auto sm:px-0 md:px-7 lg:px-36 items-start gap-4">
+      <main className="flex flex-col m-2 flex-1 overflow-auto sm:px-0 md:px-7 lg:px-36 items-center gap-4">
         {children?.[activeTab]}
       </main>
     </div>

--- a/gui/src/components/layout/SidebarButton.tsx
+++ b/gui/src/components/layout/SidebarButton.tsx
@@ -13,7 +13,7 @@ export function SidebarButton({ icon, label, isActive }: SidebarButtonProps) {
     <Button
       variant="ghost"
       className={clsx(
-        "w-full justify-start cursor-pointer mb-2 font-bold",
+        "w-full justify-start cursor-pointer mb-2 font-bold overflow-hidden",
         isActive && "bg-sidebar-primary text-sidebar-primary-foreground"
       )}
     >


### PR DESCRIPTION
- hide overflow of plugin's name in the sidebar
- center the content of a plugin page 